### PR TITLE
Fix: Storybook export 에러 수정

### DIFF
--- a/src/share/layout/HomeLayout.tsx
+++ b/src/share/layout/HomeLayout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-export default function HomeLayout({ children }: { children?: ReactNode }) {
+function HomeLayout({ children }: { children?: ReactNode }) {
   return (
     <div
       style={{
@@ -72,3 +72,5 @@ HomeLayout.Top = Top;
 HomeLayout.Center = Center;
 HomeLayout.Bottom = Bottom;
 HomeLayout.Right = Right;
+
+export default HomeLayout;

--- a/src/share/layout/Layout.tsx
+++ b/src/share/layout/Layout.tsx
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-export default function Layout({ children }: { children?: ReactNode }) {
+function Layout({ children }: { children?: ReactNode }) {
   return (
     <div
       style={{
@@ -49,3 +49,5 @@ Layout.Content = Content;
 Content.Left = LeftContent;
 Content.Right = RightContent;
 Content.Full = FullContent;
+
+export default Layout;


### PR DESCRIPTION
Storybook에서 아래처럼 compound component 패턴 사용 시 

```js
export default function Layout({ children }: { children?: ReactNode }) {}

...

Layout.LeftSideMenu = LeftSideMenu;
Layout.Content = Content;

```

아래처럼 마지막에 export 하도록 수정

```js
function Layout({ children }: { children?: ReactNode }) {}

...

Layout.LeftSideMenu = LeftSideMenu;
Layout.Content = Content;

export default Layout

```

