### PR TITLE
fix: eslint (jsx-curly-brace-presence)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,10 +37,6 @@
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error",
     "react/react-in-jsx-scope": "off",
-    "react/jsx-curly-brace-presence": [
-      "error",
-      { "props": "never", "children": "never" }
-    ],
     "@typescript-eslint/naming-convention": [
       "error",
       {


### PR DESCRIPTION
`className={}`
`className=""`

두 가지가 모두 허용되게끔 eslint 설정 파일 수정하여봤습니다.
두분 IDE 에서도 적절하게 동작하는지 테스트 부탁드립니다.

두분다 한번씩 코멘트 주시고 마지막 코멘트 다시는 분이 approve해주심 감사하겠습니다.