### PR TITLE
Feat: #44 통신 인터페이스 (CONTENT, QUIZ, VOCA)

### DIFF
--- a/src/type/contentType.ts
+++ b/src/type/contentType.ts
@@ -1,6 +1,6 @@
-import { VocaCommonRequest } from '@/type/vocaType';
+import { VocaModel } from '@/type/vocaType';
 
-export interface ContentCommonRequest {
+export interface ContentModel {
   category: number;
   title: string;
   sourceLink: string;
@@ -9,7 +9,7 @@ export interface ContentCommonRequest {
   useYn: boolean;
 }
 
-export interface ContentCommonResponse {
+export interface ContentResponseModel {
   description: string;
 }
 
@@ -17,11 +17,11 @@ export interface ContentCommonResponse {
  *  POST /api/content/add
  */
 
-export interface ContentAddRequest extends ContentCommonRequest {
+export interface ContentAddRequest extends ContentModel {
   vocaIds: number[];
 }
 
-export interface ContentAddResponse extends ContentCommonResponse {}
+export interface ContentAddResponse extends ContentResponseModel {}
 
 /*
  *  POST /api/content/delete
@@ -29,16 +29,16 @@ export interface ContentAddResponse extends ContentCommonResponse {}
 
 export type ContentDeleteRequest = number[];
 
-export interface ContentDeleteResponse extends ContentCommonResponse {}
+export interface ContentDeleteResponse extends ContentResponseModel {}
 
 /*
  *  GET /api/content/detail
  */
 
-export interface ContentDetailResponse extends ContentCommonRequest {
+export interface ContentDetailResponse extends ContentModel {
   id: number;
   memberId: number;
-  vocaList: VocaCommonRequest[];
+  vocaList: VocaModel[];
 }
 
 /*
@@ -53,7 +53,7 @@ export type ContentDownloadResponse = string;
  *  GET /api/content/list
  */
 
-export interface ContentListModel extends ContentCommonRequest {
+export interface ContentListModel extends ContentModel {
   id: number;
   categoryName: string;
   memberName: string;
@@ -72,12 +72,12 @@ export interface ContentListResponse {
  *  FormData { thumbnail, content }
  */
 
-export interface ContentUpdateRequest extends ContentCommonRequest {
+export interface ContentUpdateRequest extends ContentModel {
   id: number;
   vocaIds: number[];
 }
 
-export interface ContentUpdateResponse extends ContentCommonResponse {}
+export interface ContentUpdateResponse extends ContentResponseModel {}
 
 /*
  *  POST /api/content/upload
@@ -86,4 +86,4 @@ export interface ContentUpdateResponse extends ContentCommonResponse {}
 
 export type ContentUploadRequest = FormData;
 
-export interface ContentUploadResponse extends ContentCommonResponse {}
+export interface ContentUploadResponse extends ContentResponseModel {}

--- a/src/type/contentType.ts
+++ b/src/type/contentType.ts
@@ -1,0 +1,89 @@
+import { VocaCommonRequest } from '@/type/vocaType';
+
+export interface ContentCommonRequest {
+  category: number;
+  title: string;
+  sourceLink: string;
+  publishName: string;
+  publishDate: string;
+  useYn: boolean;
+}
+
+export interface ContentCommonResponse {
+  description: string;
+}
+
+/*
+ *  POST /api/content/add
+ */
+
+export interface ContentAddRequest extends ContentCommonRequest {
+  vocaIds: number[];
+}
+
+export interface ContentAddResponse extends ContentCommonResponse {}
+
+/*
+ *  POST /api/content/delete
+ */
+
+export type ContentDeleteRequest = number[];
+
+export interface ContentDeleteResponse extends ContentCommonResponse {}
+
+/*
+ *  GET /api/content/detail
+ */
+
+export interface ContentDetailResponse extends ContentCommonRequest {
+  id: number;
+  memberId: number;
+  vocaList: VocaCommonRequest[];
+}
+
+/*
+ *  GET /api/content/download
+ *  어떤 용도의 API 인지 모르겠음
+ *  application/octet-stream
+ */
+
+export type ContentDownloadResponse = string;
+
+/*
+ *  GET /api/content/list
+ */
+
+export interface ContentListModel extends ContentCommonRequest {
+  id: number;
+  categoryName: string;
+  memberName: string;
+  vocaContents: string;
+  createDate: string;
+  modifiedDate: string;
+}
+
+export interface ContentListResponse {
+  totalCount: number;
+  list: ContentListModel[];
+}
+
+/*
+ *  PUT /api/content/update
+ *  FormData { thumbnail, content }
+ */
+
+export interface ContentUpdateRequest extends ContentCommonRequest {
+  id: number;
+  vocaIds: number[];
+}
+
+export interface ContentUpdateResponse extends ContentCommonResponse {}
+
+/*
+ *  POST /api/content/upload
+ *  FormData { file }
+ */
+
+export type ContentUploadRequest = FormData;
+
+export interface ContentUploadResponse extends ContentCommonResponse {}

--- a/src/type/quizType.ts
+++ b/src/type/quizType.ts
@@ -1,0 +1,91 @@
+export interface QuizCommonRequest {
+  title: string;
+  answer: 1 | 2 | 3 | 4;
+  option1: string;
+  option2: string;
+  option3: string;
+  option4: string;
+  useYn: boolean;
+  vocaId: number;
+}
+
+export interface QuizCommonResponse {
+  description: string;
+}
+
+/*
+ *  POST /api/quiz/add
+ */
+
+export interface QuizAddRequest extends QuizCommonRequest {}
+
+export interface QuizAddResponse extends QuizCommonResponse {}
+
+/*
+ *  POST /api/quiz/delete
+ */
+
+export type QuizDeleteRequest = number[];
+
+export interface QuizDeleteResponse extends QuizCommonResponse {}
+
+/*
+ *  GET /api/quiz/detail
+ */
+
+export interface QuizDetailResponse extends Omit<QuizCommonRequest, 'vocaId'> {
+  id: number;
+  quizHistoryCount: number;
+  isBookmark: boolean;
+  bookmarkCount: number;
+  createdDate: string;
+  modifiedDate: string;
+  view: number;
+}
+
+/*
+ *  GET /api/quiz/download
+ *  어떤 용도의 API 인지 모르겠음
+ *  application/octet-stream
+ */
+
+export type QuizDownloadResponse = string;
+
+/*
+ *  GET /api/quiz/list
+ */
+
+export interface QuizListResponse {
+  totalCount: number;
+  list: Partial<QuizDetailResponse>[];
+}
+
+/*
+ *  PUT /api/quiz/update
+ */
+
+export interface QuizUpdateRequest extends QuizCommonRequest {
+  id: number;
+}
+
+export interface QuizUpdateResponse extends QuizCommonResponse {}
+
+/*
+ *  PATCH /api/quiz/update/useyn
+ */
+
+export interface QuizUpdateUseYnRequest {
+  quizIds: number[];
+  useYn: boolean;
+}
+
+export interface QuizUpdateUseYnResponse extends QuizCommonResponse {}
+
+/*
+ *  POST /api/quiz/upload
+ *  FormData { file }
+ */
+
+export type QuizUploadRequest = FormData;
+
+export interface QuizUploadResponse extends QuizCommonResponse {}

--- a/src/type/quizType.ts
+++ b/src/type/quizType.ts
@@ -1,4 +1,4 @@
-export interface QuizCommonRequest {
+export interface QuizModel {
   title: string;
   answer: 1 | 2 | 3 | 4;
   option1: string;
@@ -9,7 +9,7 @@ export interface QuizCommonRequest {
   vocaId: number;
 }
 
-export interface QuizCommonResponse {
+export interface QuizResponseModel {
   description: string;
 }
 
@@ -17,9 +17,9 @@ export interface QuizCommonResponse {
  *  POST /api/quiz/add
  */
 
-export interface QuizAddRequest extends QuizCommonRequest {}
+export interface QuizAddRequest extends QuizModel {}
 
-export interface QuizAddResponse extends QuizCommonResponse {}
+export interface QuizAddResponse extends QuizResponseModel {}
 
 /*
  *  POST /api/quiz/delete
@@ -27,13 +27,13 @@ export interface QuizAddResponse extends QuizCommonResponse {}
 
 export type QuizDeleteRequest = number[];
 
-export interface QuizDeleteResponse extends QuizCommonResponse {}
+export interface QuizDeleteResponse extends QuizResponseModel {}
 
 /*
  *  GET /api/quiz/detail
  */
 
-export interface QuizDetailResponse extends Omit<QuizCommonRequest, 'vocaId'> {
+export interface QuizDetailResponse extends Omit<QuizModel, 'vocaId'> {
   id: number;
   quizHistoryCount: number;
   isBookmark: boolean;
@@ -64,11 +64,11 @@ export interface QuizListResponse {
  *  PUT /api/quiz/update
  */
 
-export interface QuizUpdateRequest extends QuizCommonRequest {
+export interface QuizUpdateRequest extends QuizModel {
   id: number;
 }
 
-export interface QuizUpdateResponse extends QuizCommonResponse {}
+export interface QuizUpdateResponse extends QuizResponseModel {}
 
 /*
  *  PATCH /api/quiz/update/useyn
@@ -79,7 +79,7 @@ export interface QuizUpdateUseYnRequest {
   useYn: boolean;
 }
 
-export interface QuizUpdateUseYnResponse extends QuizCommonResponse {}
+export interface QuizUpdateUseYnResponse extends QuizResponseModel {}
 
 /*
  *  POST /api/quiz/upload
@@ -88,4 +88,4 @@ export interface QuizUpdateUseYnResponse extends QuizCommonResponse {}
 
 export type QuizUploadRequest = FormData;
 
-export interface QuizUploadResponse extends QuizCommonResponse {}
+export interface QuizUploadResponse extends QuizResponseModel {}

--- a/src/type/vocaType.ts
+++ b/src/type/vocaType.ts
@@ -1,4 +1,4 @@
-export interface VocaCommonRequest {
+export interface VocaModel {
   id: number;
   koreanTitle: string;
   englishTitle: string;
@@ -7,7 +7,7 @@ export interface VocaCommonRequest {
   modifiedDate: string;
 }
 
-export interface VocaCommonResponse {
+export interface VocaResponseModel {
   description: string;
 }
 
@@ -18,7 +18,7 @@ export interface VocaCommonResponse {
 
 export type VocaAddRequest = FormData;
 
-export interface VocaAddResponse extends VocaCommonResponse {}
+export interface VocaAddResponse extends VocaResponseModel {}
 
 /*
  *  POST /api/voca/delete
@@ -26,13 +26,13 @@ export interface VocaAddResponse extends VocaCommonResponse {}
 
 export type VocaDeleteRequest = number[];
 
-export interface VocaDeleteResponse extends VocaCommonResponse {}
+export interface VocaDeleteResponse extends VocaResponseModel {}
 
 /*
  *  GET /api/voca/detail
  */
 
-export interface VocaDetailResponse extends VocaCommonRequest {
+export interface VocaDetailResponse extends VocaModel {
   koreanCategory: string;
   englishCategory: string;
   content: string;
@@ -62,7 +62,7 @@ export type VocaDownloadResponse = string;
 
 export interface VocaListResponse {
   totalCount: number;
-  list: VocaCommonRequest[];
+  list: VocaModel[];
 }
 
 /*
@@ -72,7 +72,7 @@ export interface VocaListResponse {
 
 export type VocaUpdateRequest = FormData;
 
-export interface VocaUpdateResponse extends VocaCommonResponse {}
+export interface VocaUpdateResponse extends VocaResponseModel {}
 
 /*
  *  PATCH /api/voca/update/useyn
@@ -83,7 +83,7 @@ export interface VocaUpdateUseYnRequest {
   useYn: boolean;
 }
 
-export interface VocaUpdateUseYnResponse extends VocaCommonResponse {}
+export interface VocaUpdateUseYnResponse extends VocaResponseModel {}
 
 /*
  *  POST /api/voca/upload
@@ -92,4 +92,4 @@ export interface VocaUpdateUseYnResponse extends VocaCommonResponse {}
 
 export type VocaUploadRequest = FormData;
 
-export interface VocaUploadResponse extends VocaCommonResponse {}
+export interface VocaUploadResponse extends VocaResponseModel {}

--- a/src/type/vocaType.ts
+++ b/src/type/vocaType.ts
@@ -1,0 +1,95 @@
+export interface VocaCommonRequest {
+  id: number;
+  koreanTitle: string;
+  englishTitle: string;
+  useYn: boolean;
+  createdDate: string;
+  modifiedDate: string;
+}
+
+export interface VocaCommonResponse {
+  description: string;
+}
+
+/*
+ *  POST /api/voca/add
+ *  FormData { thumbnail, voca }
+ */
+
+export type VocaAddRequest = FormData;
+
+export interface VocaAddResponse extends VocaCommonResponse {}
+
+/*
+ *  POST /api/voca/delete
+ */
+
+export type VocaDeleteRequest = number[];
+
+export interface VocaDeleteResponse extends VocaCommonResponse {}
+
+/*
+ *  GET /api/voca/detail
+ */
+
+export interface VocaDetailResponse extends VocaCommonRequest {
+  koreanCategory: string;
+  englishCategory: string;
+  content: string;
+  thumbnailPath: string;
+  thumbnailName: string;
+  sourceName: string;
+  sourceLink: string;
+  thumbnailSourceName: string;
+  thumbnailSourceLink: string;
+  helpful: number;
+  bookmarkCount: number;
+  quizId: number;
+  quizTitle: string;
+}
+
+/*
+ *  GET /api/voca/download
+ *  어떤 용도의 API 인지 모르겠음
+ *  application/octet-stream
+ */
+
+export type VocaDownloadResponse = string;
+
+/*
+ *  GET /api/voca/list
+ */
+
+export interface VocaListResponse {
+  totalCount: number;
+  list: VocaCommonRequest[];
+}
+
+/*
+ *  PUT /api/voca/update
+ *  FormData { thumbnail, voca }
+ */
+
+export type VocaUpdateRequest = FormData;
+
+export interface VocaUpdateResponse extends VocaCommonResponse {}
+
+/*
+ *  PATCH /api/voca/update/useyn
+ */
+
+export interface VocaUpdateUseYnRequest {
+  vocaIds: number[];
+  useYn: boolean;
+}
+
+export interface VocaUpdateUseYnResponse extends VocaCommonResponse {}
+
+/*
+ *  POST /api/voca/upload
+ *  FormData { file }
+ */
+
+export type VocaUploadRequest = FormData;
+
+export interface VocaUploadResponse extends VocaCommonResponse {}


### PR DESCRIPTION
공통된 property들은 최대한 extends를 사용해서 작성해봤습니다.

실무에서는 오히려, 하드코딩을 더 하는 쪽으로 작업해왔는데 이번에는 이렇게 상속 받는 방식으로 하는게 어떤 효과가 있을지...

오히려 Type 확인을 할 때에 더 혼란스러울지 모르겠네요.

만약 Swagger 문서를 기분으로 extends를 안쓰는 방향이 더 낫겠다고 판단되시면 피드백 부탁드립니다.